### PR TITLE
Ajout d'une variable pour «optionnaliser» la gestion du repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g
 
 elasticsearch_extra_options: ''
+
+config_system: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,12 +10,16 @@
   apt_key:
     url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  when:
+    - config_system
 
 - name: Add Elasticsearch repository.
   apt_repository:
     repo: 'deb https://artifacts.elastic.co/packages/{{ elasticsearch_version }}/apt stable main'
     state: present
     update_cache: true
+  when:
+    - config_system
 
 - name: Install Elasticsearch.
   package:


### PR DESCRIPTION
## Raison

Pour puvoir déployer les applications chez des clients qui gérent eux-même les repository debian, on rend optionnel la création et la gestion des sources-list dans nos roles ansibles.