### PR TITLE
feat: externalisation de la conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ elasticsearch_service_enabled: true
 
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
+elasticsearch_log: /var/log/elasticsearch
+elasticsearch_data: /var/lib/elasticsearch
 
 elasticsearch_heap_size_min: 1g
 elasticsearch_heap_size_max: 2g

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -31,11 +31,11 @@
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: /var/lib/elasticsearch
+path.data: {{ elasticsearch_data }}
 #
 # Path to log files:
 #
-path.logs: /var/log/elasticsearch
+path.logs: {{ elasticsearch_log }}
 #
 # ----------------------------------- Memory -----------------------------------
 #


### PR DESCRIPTION
Le but de la PR est de permettre de changer les répertoires par défaut de path.data et de path.log.

Reprise du travail de chadek :
https://github.com/geerlingguy/ansible-role-elasticsearch/pull/95 