### PR TITLE
Rechargement des démons lors du redémarrage du service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart elasticsearch
-  service: name=elasticsearch state=restarted
+  service: name=elasticsearch state=restarted daemon_reload=true


### PR DESCRIPTION
## Problème

Lors du passage à la version majeure `8` d'Elasticseach, le script du service `elasticsearch` change et le redémarrage ne fonctionne plus.

L'installation d'Elasticsearch est donc bloquée et la mise à jour des applications aussi.

## Solution

Rechargement de systemd lors du redémarrage d'Elasticsearch, via l'option `daemon_reload`, pour qu'il prenne en compte le nouveau service `elasticsearch` à la place de l'ancien.
