### PR TITLE
Redémarrage du démon systemd uniquement lorsque nécessaire

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,9 @@
 ---
+- name: Check if service manager is supported
+  fail:
+    msg: "Unsupported service manager: {{ ansible_service_mgr }}"
+  when: ansible_service_mgr not in ['systemd', 'sysvinit']
+
 - name: restart elasticsearch
-  service: name=elasticsearch state=restarted daemon_reload=true
+  include_tasks: "restart/{{ ansible_service_mgr }}.yml"
+  when: ansible_service_mgr in ['systemd', 'sysvinit']

--- a/handlers/restart/systemd.yml
+++ b/handlers/restart/systemd.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart elasticsearch with systemd
+  systemd:
+    name: elasticsearch
+    state: restarted
+    daemon_reload: true

--- a/handlers/restart/sysvinit.yml
+++ b/handlers/restart/sysvinit.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart elasticsearch with service (no systemd)
+  service:
+    name: elasticsearch
+    state: restarted


### PR DESCRIPTION
## Problème

Suite au redémarrage du démon de `systemd` lors du redémarrage d'Elasticsearch (voir #4), le rôle n'est plus utilisable dans Docker : effectivement, Docker n'utilise pas `systemd` comme gestionnaire de service mais `sysvinit` qui ne dispose pas de l'option `daemon_reload`.

L'erreur suivante apparait donc lorsque l'on essaie de construire l'image Docker :

```shell
RUNNING HANDLER [../roles/elasticsearch : restart elasticsearch] ***************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.sysvinit) module: daemon_reload. Supported parameters include: arguments, daemonize, enabled, name, pattern, runlevels, sleep, state (args, service)."}
```

## Solution

Adaptation du handler `restart elasticsearch` selon le gestionnaire de service utilisé : la version avec `systemd` utilise l'option `daemon_reload` mais pas la version avec `sysvinit`.

Le principe est de charger un fichier différent selon le gestionnaire de service détecté, contenant la bonne action à réaliser.
