### PR TITLE
Gestion du service coté docker.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,29 @@
   notify: restart elasticsearch
   when: elasticsearch_version[0] | int >= 7
 
+- name: Clean des nodes en docker
+  file:
+    path: '{{ item }}'
+    state: absent
+  loop:
+    - "/var/lib/elasticsearch/nodes/0/node.lock"
+    - "/var/lib/elasticsearch/nodes/0/snapshot_cache/write.lock"
+    - "/etc/elasticsearch/elasticsearch.keystore"
+  when: docker_env.stat.exists == True
+
+- name: Regenerate keystore en docker
+  shell: /usr/share/elasticsearch/bin/elasticsearch-keystore create
+  when: docker_env.stat.exists == True
+
+- name: Generation du fichier systemV en docker
+  copy:
+    src: "../templates/elasticsearch"
+    dest: "/etc/init.d/elasticsearch"
+    owner: root
+    group: root
+    mode: 0750
+  when: docker_env.stat.exists == True
+
 - name: Force a restart if configuration has changed.
   meta: flush_handlers
 
@@ -52,7 +75,6 @@
     name: elasticsearch
     state: "{{ elasticsearch_service_state }}"
     enabled: "{{ elasticsearch_service_enabled }}"
-  when: docker_env.stat.exists == False
 
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for:
@@ -60,4 +82,3 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 3
     timeout: 300
-  when: docker_env.stat.exists == False

--- a/templates/elasticsearch
+++ b/templates/elasticsearch
@@ -1,0 +1,176 @@
+#!/bin/bash
+#
+# /etc/init.d/elasticsearch -- startup script for Elasticsearch
+#
+### BEGIN INIT INFO
+# Provides:          elasticsearch
+# Required-Start:    $network $remote_fs $named
+# Required-Stop:     $network $remote_fs $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts elasticsearch
+# Description:       Starts elasticsearch using start-stop-daemon
+### END INIT INFO
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+NAME=elasticsearch
+DESC="Elasticsearch Server"
+DEFAULT=/etc/default/$NAME
+
+if [ `id -u` -ne 0 ]; then
+	echo "You need root privileges to run this script"
+	exit 1
+fi
+
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+	. /etc/default/rcS
+fi
+
+
+# The following variables can be overwritten in $DEFAULT
+
+# Directory where the Elasticsearch binary distribution resides
+ES_HOME=/usr/share/$NAME
+
+# Additional Java OPTS
+#ES_JAVA_OPTS=
+
+# Maximum number of open files
+MAX_OPEN_FILES=65535
+
+# Maximum amount of locked memory
+#MAX_LOCKED_MEMORY=
+
+# Elasticsearch configuration directory
+ES_PATH_CONF=/etc/$NAME
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+MAX_MAP_COUNT=262144
+
+# Elasticsearch PID file directory
+PID_DIR="/var/run/elasticsearch"
+
+# End of variables that can be overwritten in $DEFAULT
+
+# overwrite settings from default file
+if [ -f "$DEFAULT" ]; then
+	. "$DEFAULT"
+fi
+
+# ES_USER and ES_GROUP settings were removed
+if [ ! -z "$ES_USER" ] || [ ! -z "$ES_GROUP" ]; then
+    echo "ES_USER and ES_GROUP settings are no longer supported. To run as a custom user/group use the archive distribution of Elasticsearch."
+    exit 1
+fi
+
+# Define other required variables
+PID_FILE="$PID_DIR/$NAME.pid"
+DAEMON=$ES_HOME/bin/elasticsearch
+DAEMON_OPTS="-d -p $PID_FILE"
+
+export ES_JAVA_OPTS
+export ES_JAVA_HOME
+export JAVA_HOME
+export ES_PATH_CONF
+
+if [ -n "$LIBFFI_TMPDIR" ]; then
+  export LIBFFI_TMPDIR
+fi
+
+if [ ! -x "$DAEMON" ]; then
+	echo "The elasticsearch startup script does not exists or it is not executable, tried: $DAEMON"
+	exit 1
+fi
+
+case "$1" in
+  start)
+
+	log_daemon_msg "Starting $DESC"
+
+	pid=`pidofproc -p $PID_FILE elasticsearch`
+	if [ -n "$pid" ] ; then
+		log_begin_msg "Already running."
+		log_end_msg 0
+		exit 0
+	fi
+
+	# Ensure that the PID_DIR exists (it is cleaned at OS startup time)
+	if [ -n "$PID_DIR" ] && [ ! -e "$PID_DIR" ]; then
+		mkdir -p "$PID_DIR" && chown elasticsearch:elasticsearch "$PID_DIR"
+	fi
+	if [ -n "$PID_FILE" ] && [ ! -e "$PID_FILE" ]; then
+		touch "$PID_FILE" && chown elasticsearch:elasticsearch "$PID_FILE"
+	fi
+
+	if [ -n "$MAX_OPEN_FILES" ]; then
+		ulimit -n $MAX_OPEN_FILES
+	fi
+
+	if [ -n "$MAX_LOCKED_MEMORY" ]; then
+		ulimit -l $MAX_LOCKED_MEMORY
+	fi
+
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ] && [ "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
+		sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
+	fi
+
+	# Start Daemon
+	start-stop-daemon -d $ES_HOME --start --user elasticsearch -c elasticsearch --pidfile "$PID_FILE" --exec $DAEMON -- $DAEMON_OPTS
+	return=$?
+	if [ $return -eq 0 ]; then
+		i=0
+		timeout=10
+		# Wait for the process to be properly started before exiting
+		until { kill -0 `cat "$PID_FILE"`; } >/dev/null 2>&1
+		do
+			sleep 1
+			i=$(($i + 1))
+			if [ $i -gt $timeout ]; then
+				log_end_msg 1
+				exit 1
+			fi
+		done
+	fi
+	log_end_msg $return
+	exit $return
+	;;
+  stop)
+	log_daemon_msg "Stopping $DESC"
+
+	if [ -f "$PID_FILE" ]; then
+		start-stop-daemon --stop --pidfile "$PID_FILE" \
+			--user elasticsearch \
+			--quiet \
+			--retry forever/TERM/20 > /dev/null
+		if [ $? -eq 1 ]; then
+			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+		elif [ $? -eq 3 ]; then
+			PID="`cat $PID_FILE`"
+			log_failure_msg "Failed to stop $DESC (pid $PID)"
+			exit 1
+		fi
+		rm -f "$PID_FILE"
+	else
+		log_progress_msg "(not running)"
+	fi
+	log_end_msg 0
+	;;
+  status)
+	status_of_proc -p $PID_FILE elasticsearch elasticsearch && exit 0 || exit $?
+	;;
+  restart|force-reload)
+	if [ -f "$PID_FILE" ]; then
+		$0 stop
+	fi
+	$0 start
+	;;
+  *)
+	log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
+	exit 1
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
On met en place ce qu'il faut pour pouvoir lancer correctement elasticsearch comme un service dans docker.

La seule utilité de l'ensemble est de pouvoir lancer l'installation «classique» pour contrôler la liste des noms de domaines utilisés.