### PR TITLE
Arrêt du playbook avant le redémarrage d'ES lors d'une construction d'image Docker

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,16 @@
       - apt-transport-https
       - gnupg2
     state: present
-- name: Detection Docker
+
+- name: Detection de l'environnement Docker
   stat:
     path: /.dockerenv
   register: docker_env
+
+- name: Detection du build Docker
+  stat:
+    path: /.dockerbuild
+  register: docker_build
 
 - name: Add Elasticsearch apt key.
   apt_key:
@@ -52,7 +58,17 @@
     owner: root
     group: root
     mode: 0750
-  when: docker_env.stat.exists == True
+  when: docker_env.stat.exists | bool
+
+# Impossible de démarrer ES dans un environnement Docker amd64 en émulation depuis un hôte arm64 avec Docker Desktop.
+# L'option CONFIG_SECCOMP n'est pas compilée dans le noyau "linuxkit amd64" utilisé par Docker Desktop pour l'émulation amd64 sur une machine arm64.
+# Ce qui est obligatoire pour le fonctionnement d'Elasticsearch 8+.
+# Voir notamment : https://github.com/docker/for-mac/issues/7410
+# Cette situation n'apparait que lors du build de l'image multiarch.
+# De plus il est inutile de démarrer ES lors du build d'une image.
+- name: Quitte le playbook si on build une image Docker
+  meta: end_play
+  when: docker_build.stat.exists | bool
 
 - name: Force a restart if configuration has changed.
   meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,23 @@
   notify: restart elasticsearch
   when: elasticsearch_version[0] | int >= 7
 
+# Suppression et régénération du Keystore en environnement Docker, car ES 8+ active
+# la sécurité par défaut : le Keystore est généré à l'installation d'ES avec des configurations
+# de sécurité activées même si la variable 'transport.ssl.enabled' est à false (ce qui est le cas).
+# Il y a donc une incohérence entre le keystore et le paramétrage de l'application (diantre),
+# et le serveur ne démarre pas.
+# En regénérant le keystore, ce dernier correspond à la vraie configuration d'ES.
+# En dehors du contexte de Docker, la même bidouille est faite, mais automatiquement par Systemd.
+- name: Suppression du Keystore en environnement Docker
+  file:
+    path: /etc/elasticsearch/elasticsearch.keystore
+    state: absent
+  when: docker_env.stat.exists | bool
+
+- name: Régénération du Keystore en environnement Docker
+  shell: /usr/share/elasticsearch/bin/elasticsearch-keystore create
+  when: docker_env.stat.exists | bool
+
 - name: Generation du fichier systemV en docker
   copy:
     src: "../templates/elasticsearch"


### PR DESCRIPTION
## Problème

Lors du build d'une image Docker multi-architectures (amd64/arm64) il est impossible de démarrer ES dans un environnement Docker amd64 émulé depuis Docker Desktop sur un hôte arm64.

Effectivement, l'option `CONFIG_SECCOMP` n'est pas compilée dans le noyau `linuxkit amd64` utilisé par Docker Desktop pour l'émulation amd64 sur une machine arm64.

Or cette option est obligatoire pour que Elasticsearch puisse démarrer (depuis sa version `8`).

Voir notamment : https://github.com/docker/for-mac/issues/7410

## Solution

Comme cette situation (être dans un environnement Docker amd64 émulé) n'apparait que lors de la construction d'une image multi-architectures, j'ai créé un nouveau fichier `/.dockerbuild` utilisé dans le `Dockerfile-Vagrant` de MGX qui permet au rôle de savoir s'il est dans un contexte de _build_.

Si c'est le cas, le rôle s'arrête avant de redémarrer Elasticsearch.

## Remarque

Lorsque cette correction a réussi à construire l'image Docker, il y a eu un autre problème. Celui-ci a aussi été corrigé dans cette même PR en ré-ajoutant la suppression et régénération du keystore en environnement Docker qui avait été supprimé dans #9 mais jamais taggé (sinon on aurait vu que cela ne fonctionnait pas).

La cause est qu'ES 8+ active la sécurité par défaut : le keystore est généré à l'installation d'ES avec des configurations de sécurité activées même si la variable `transport.ssl.enabled` est à `false` (ce qui est notre cas).

S'ensuit une incohérence entre le keystore et le paramétrage de l'application (diantre) faisant que le serveur ne démarre même plus. En régénérant le keystore, ce dernier correspond à la vraie configuration d'ES et le serveur démarre.

IEn dehors du contexte de Docker, il semblerait que la même bidouille soit faite, mais automatiquement par Systemd dans un script de _postinstall_.

